### PR TITLE
feat: upgrade: add Yarn parser to parse yarn dependencies 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Additionally, CVE tracker supports collecting dependencies from files for the fo
 * [NPM](https://www.npmjs.com/)
 * [PIP](https://pip.pypa.io/)
 * [Make](https://www.gnu.org/software/make/manual/make.html)
+* [Yarn](https://yarnpkg.com/)
 
 Additionally, a CSV parser, and JSON parser are available for cases where it is necessary to monitor for CVEs in infrastructure components (e.g. Kubernetes) and dependencies that are in unsupported package manager and build system files.
 
@@ -25,7 +26,7 @@ Once dependencies are collected, CVE Tracker uses the [NIST API](https://nvd.nis
 ## Features
  
 * Automatically finds dependency definitions in files stored in [GitHub](https://github.com/), [GitLab](https://gitlab.com/), or the local filesystem
-* Supports parsing dependency files in the following formats: `bazel`, `conan`, `pip`, `npm`, `json`, `.mk`, and `csv`
+* Supports parsing dependency files in the following formats: `bazel`, `conan`, `pip`, `npm`, `json`, `.mk`, `yarn.lock`, and `csv`
 * Automatically finds license data for dependencies
 * Relies on the [NIST API](https://nvd.nist.gov/developers/vulnerabilities) as an accurate source of current CVE data
 * Supports HTML and JSON reports

--- a/config/config.py
+++ b/config/config.py
@@ -6,7 +6,7 @@ from src.dependency_searchers.dependency_searchers import LocalFileSearcher, \
 from src.dependency_searchers.package_parsers import BazelParser, CsvParser, \
     NpmParser, PipParser, \
     ConanParser, JsonParser, \
-    MakeFileParser
+    MakeFileParser, YarnParser
 from src.report_creators.html_report_visitor import HtmlReportVisitor
 from src.report_creators.json_report_visitor import JsonReportVisitor
 from src.notification.email import EmailNotifier
@@ -43,6 +43,8 @@ class Config:
             Example search pattern: {"sources.json": JsonParser()}
         * MakeFileParser() - For *.mk package files.
             Example search pattern: {"*.mk": MakeFileParser()}
+        * YarnParser() - For *yarn.lock package files.
+            Example search pattern: {"yarn.lock": YarnParser()}
 
     When your dependencies have assigned CVEs, this tool produces either an HTML or JSON report
     when the HtmlReportVisitor() or JsonReportVisitor() are configured. You can choose to have a

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ bs4==0.0.1
 packaging==21.0
 beautifulsoup4==4.10.0
 python-gitlab~=2.10
+pyarn~=0.1.3
 

--- a/run.py
+++ b/run.py
@@ -4,7 +4,7 @@ import textwrap
 import argparse
 
 version_major = 1
-version_minor = 2
+version_minor = 3
 version_bug = 0
 version = str(version_major) + '.' + str(version_minor) + '.' + str(version_bug)
 

--- a/src/report_creators/html_report_visitor.py
+++ b/src/report_creators/html_report_visitor.py
@@ -115,6 +115,7 @@ table.darkTable tfoot td {
   <button class="tablinks" onclick="openPackageReport(event, 'Pip Dependencies')">Pip Dependencies</button>
   <button class="tablinks" onclick="openPackageReport(event, 'NPM Dependencies')">NPM Dependencies</button>
   <button class="tablinks" onclick="openPackageReport(event, 'MakeFile Dependencies')">MakeFile Dependencies</button>
+  <button class="tablinks" onclick="openPackageReport(event, 'Yarn Dependencies')">Yarn Dependencies</button>
   <button class="tablinks" onclick="openPackageReport(event, 'Local Source Dependencies')">Local Source Dependencies</button>
   <button class="tablinks" onclick="openPackageReport(event, 'license_data')">License Data</button>
 </div>"""

--- a/tests/test_yarn_parser.py
+++ b/tests/test_yarn_parser.py
@@ -1,0 +1,34 @@
+import unittest
+from src.dependency_searchers.package_parsers import YarnParser
+
+class TestYarnParser(unittest.TestCase):
+
+    def test_parse_valid_yarn_file(self):
+        package_contents = """"@adobe/code-frame@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.npmjs.org/"
+  integrity sha512-+uad9NC
+"""
+        dependencies = YarnParser().parse(package_contents)
+        self.assertEqual(len(dependencies), 1)
+        self.assertEqual(dependencies[0]['ModuleName'], 'code_frame')
+        self.assertEqual(dependencies[0]['Version'], '7.10.4')
+        self.assertEqual(dependencies[0]['License'], 'MIT')
+
+    def test_invalid_yarn_file(self):
+        package_contents = ''
+        dependencies = YarnParser().parse(package_contents)
+        self.assertEqual(len(dependencies), 0)
+
+
+    def test_yarn_file_with_no_license_data(self):
+        package_contents = """"@adobe/css-tools@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/"
+  integrity sha512-+uad9NC
+"""
+        dependencies = YarnParser().parse(package_contents)
+        self.assertEqual(len(dependencies), 1)
+        self.assertEqual(dependencies[0]['ModuleName'], 'css_tools')
+        self.assertEqual(dependencies[0]['Version'], '4.0.1')
+        self.assertEqual(dependencies[0]['License'], 'N/A')


### PR DESCRIPTION
This PR is to add the makefile parser to parse yarn dependencies, and updates several additional files listed below

Changes

add yarn parser to package parsers
update README for yarn parser
update config for yarn parser
update html report for yarn parser
add yarn parser unit test
update cve_tracker version to 1.3