### PR TITLE
Fix: searcher config

### DIFF
--- a/src/cve_tracker.py
+++ b/src/cve_tracker.py
@@ -236,7 +236,7 @@ def main():
 
         if "search_relative_path" in searcher_config:
                 dependencies.extend(
-                    searcher_config["search_uri"].search(searcher_config["search_pattern"]))
+                    searcher_config["search_uri"].search(searcher_config["search_pattern"], searcher_config['search_relative_path']))
 
     cves = NistCveSearcher().cve_search(dependencies, Config.NIST_TOKEN)
 


### PR DESCRIPTION
This PR fixes the searcher_config by adding the search_relative_path to the searcher_config on line 239 of cve_tracker.py

Unit test results:
Ran 50 tests in 2.564s
OK