### PR TITLE
feat: upgrade: add GoParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Additionally, CVE tracker supports collecting dependencies from files for the fo
 
 * [Bazel](https://bazel.build/)
 * [Conan](https://conan.io/)
+* [Go](https://go.dev/)
 * [NPM](https://www.npmjs.com/)
 * [PIP](https://pip.pypa.io/)
 * [Make](https://www.gnu.org/software/make/manual/make.html)
@@ -27,7 +28,7 @@ Once dependencies are collected, CVE Tracker uses the [NIST API](https://nvd.nis
 ## Features
  
 * Automatically finds dependency definitions in files stored in [GitHub](https://github.com/), [GitLab](https://gitlab.com/), or the local filesystem
-* Supports parsing dependency files in the following formats: `bazel`, `conan`, `pip`, `npm`, `json`, `.mk`, `yarn.lock` and `csv`
+* Supports parsing dependency files in the following formats: `bazel`, `conan`, `pip`,`go.mod`, `npm`, `json`, `.mk`, `yarn.lock` and `csv`
 * Automatically finds license data for dependencies
 * Relies on the [NIST API](https://nvd.nist.gov/developers/vulnerabilities) as an accurate source of current CVE data
 * Supports HTML and JSON reports

--- a/config/config.py
+++ b/config/config.py
@@ -6,7 +6,8 @@ from src.dependency_searchers.dependency_searchers import LocalFileSearcher, \
 from src.dependency_searchers.package_parsers import ArtifactoryParser, BazelParser, \
     CsvParser, NpmParser, PipParser, \
     ConanParser, JsonParser, \
-    MakeFileParser, YarnParser
+    MakeFileParser, YarnParser, \
+    GoParser
 from src.report_creators.html_report_visitor import HtmlReportVisitor
 from src.report_creators.json_report_visitor import JsonReportVisitor
 from src.notification.email import EmailNotifier
@@ -45,6 +46,8 @@ class Config:
             Example search pattern: {"*.mk": MakeFileParser()}
         * YarnParser() - For *yarn.lock package files.
             Example search pattern: {"yarn.lock": YarnParser()}
+        * GoParser() - For *go.mod package files.
+            Example search pattern: {"go.mod": GoParser()}
 
     When your dependencies have assigned CVEs, this tool produces either an HTML or JSON report
     when the HtmlReportVisitor() or JsonReportVisitor() are configured. You can choose to have a

--- a/run.py
+++ b/run.py
@@ -4,7 +4,7 @@ import textwrap
 import argparse
 
 version_major = 1
-version_minor = 5
+version_minor = 6
 version_bug = 0
 version = str(version_major) + '.' + str(version_minor) + '.' + str(version_bug)
 

--- a/src/report_creators/html_report_visitor.py
+++ b/src/report_creators/html_report_visitor.py
@@ -113,6 +113,7 @@ table.darkTable tfoot td {
   <button class="tablinks" onclick="openPackageReport(event, 'Artifactory Dependencies')">Artifactory Dependencies</button>
   <button class="tablinks" onclick="openPackageReport(event, 'Bazel Dependencies')">Bazel Dependencies</button>
   <button class="tablinks" onclick="openPackageReport(event, 'Conan Dependencies')">Conan Dependencies</button>
+  <button class="tablinks" onclick="openPackageReport(event, 'Go Dependencies')">Go Dependencies</button>
   <button class="tablinks" onclick="openPackageReport(event, 'Pip Dependencies')">Pip Dependencies</button>
   <button class="tablinks" onclick="openPackageReport(event, 'NPM Dependencies')">NPM Dependencies</button>
   <button class="tablinks" onclick="openPackageReport(event, 'MakeFile Dependencies')">MakeFile Dependencies</button>

--- a/tests/test_go_parser.py
+++ b/tests/test_go_parser.py
@@ -1,0 +1,59 @@
+import unittest
+from src.dependency_searchers.package_parsers import GoParser
+
+
+class TestGoParser(unittest.TestCase):
+
+    def test_go_parser_with_valid_file(self):
+        package_contents = """module go_module/for/this/example
+
+        go 1.0
+
+
+        require (
+        	github.com/golang/protobuf v1.5.3 // indirect
+        	google.golang.org/protobuf v1.30.0 // indirect
+        """
+
+        dependencies = GoParser().parse(package_contents)
+        self.assertEqual(len(dependencies), 2)
+
+        self.assertEqual(dependencies[0]['ModuleName'], 'protobuf')
+        self.assertEqual(dependencies[0]['Version'], '1.5.3')
+        self.assertEqual(dependencies[0]['License'], 'BSD-3-Clause')
+
+        self.assertEqual(dependencies[1]['ModuleName'], 'protobuf')
+        self.assertEqual(dependencies[1]['Version'], '1.30.0')
+        self.assertEqual(dependencies[1]['License'], 'BSD-3-Clause')
+
+    def test_go_parser_with_invalid_file(self):
+        package_contents = """module go_module/for/this/example
+
+go 1.0
+
+require (
+	google.golang.org/MISSING Dependencies 
+)
+
+"""
+
+        dependencies = GoParser().parse(package_contents)
+
+        self.assertEqual(len(dependencies), 0)
+
+    def test_go_parser_with_no_license(self):
+        package_contents = """module go_module/in/this/location
+
+        go 1.0
+
+
+        require (
+        	golang.org/x/net v0.1.1 // indirect
+        """
+        dependencies = GoParser().parse(package_contents)
+
+        self.assertEqual(len(dependencies), 1)
+        self.assertEqual(dependencies[0]['ModuleName'], 'net')
+        self.assertEqual(dependencies[0]['Version'], '0.1.1')
+        self.assertEqual(dependencies[0]['License'], 'N/A')
+


### PR DESCRIPTION
This MR is to add the GoParser to parse Go dependencies, and updates several additional files listed below.
Changes

add GoParser to package_parsers.py
add go unit tests with test_go_parser
update config and README for new parser
update cve_tracker to 1.6

Unit Test Results
test_go_parser.py::test_go_parser_with_valid_file
test_go_parser.py::test_go_parser_with_invalid_file
test_go_parser.py::test_go_parser_with_no_license
Ran 3 tests in 0.045s
OK