### PR TITLE
Improve CLI and logging output when there is no report or a NIST API error occurs

### DIFF
--- a/src/cve_tracker.py
+++ b/src/cve_tracker.py
@@ -270,3 +270,5 @@ def main():
         report_creator = ReportCreator(Config.REPORT_FILE_NAME + Config.REPORT_EXTENSION,
                                        Config.REPORT_VISITOR, dependencies, Config.NOTIFIER)
         report_creator.create_report(cves)
+    else:
+        print("No CVEs were found. No report will be generated.")

--- a/src/cve_tracker.py
+++ b/src/cve_tracker.py
@@ -86,8 +86,8 @@ class NistCveSearcher():
                         time.sleep(0.6)
 
             else:
-                logging.error("The NIST API returned the following error code: %d",
-                              search_result.status_code)
+                logging.error("The NIST API returned error code %d when searching for %s",
+                              search_result.status_code, mod_name)
             return cves
 
         except requests.exceptions.ConnectionError:


### PR DESCRIPTION
Basically:

1. If there are no CVEs there will be report generated. When this occurs, CVE Tracker silently terminates. This causes people who are new to CVE Tracker, or who haven't used it in a while, to wonder if the tool worked at all. This PR adds a new output message to remedy that.

2. When the NIST search request results in an error response, CVE Tracker failed to check for CVEs in a particular module. There may be CVEs, we just don't know because the query failed. This PR updates the log message used when this error occurs to state the module name that was queried so that a reader of a partial report knows a module is missing solely because the request failed, not because the module is free of CVEs.