### PR TITLE
Use strip_prefix as a means to detect a module name and version

### DIFF
--- a/src/dependency_searchers/package_parsers.py
+++ b/src/dependency_searchers/package_parsers.py
@@ -99,12 +99,18 @@ class BazelParser(PackageParser):
             if name:
                 version_pattern = re.compile(
                     r'\s*http.*' + name + r'-([a-zA-Z0-9-\.]*)\.tar|' + \
-                    r'\s*http.*' + name + r'-([a-zA-Z0-9-\.]*)\.')
+                    r'\s*http.*' + name + r'-([a-zA-Z0-9-\.]*)\.|' + \
+                    r'\s*strip_prefix\s*=\s*(?:\"|\')' + name + r'-(.*)(?:\"|\')')
 
                 match = version_pattern.search(line)
 
                 if match:
-                    version_match = match.group(1) if match.group(1) else match.group(2)
+                    if match.group(1):
+                        version_match = match.group(1)
+                    elif match.group(2):
+                        version_match = match.group(2)
+                    else:
+                        version_match = match.group(3)
 
                     # some version numbers have a 'v' before the version number and some version numbers
                     # have a '-latest' at the end, we need to remove this to accurately match the version


### PR DESCRIPTION
Some bazel repositories use the strip_prefix field with the value in the <module_name>-<version> format. This PR causes CVE Tracker to use this as the third option for finding a module name and version number if the approach where the URL is parsed fails. This increases coverage for some repositories.