### PR TITLE
Only send the apiKey header in NIST API requests if a NIST_TOKEN is set

### DIFF
--- a/src/cve_tracker.py
+++ b/src/cve_tracker.py
@@ -69,7 +69,11 @@ class NistCveSearcher():
         nvd_search_url = 'https://services.nvd.nist.gov/rest/json/cves/2.0?keywordSearch='
 
         try:
-            search_result = requests.get(url = nvd_search_url + mod_name, headers={'apiKey': nist_api_key})
+            if nist_api_key:
+                search_result = requests.get(url = nvd_search_url + mod_name, headers={'apiKey': nist_api_key})
+            else:
+                search_result = requests.get(url = nvd_search_url + mod_name)
+
             if search_result.ok:
                 result_json = search_result.json()
                 if 'error' in result_json:

--- a/src/cve_tracker.py
+++ b/src/cve_tracker.py
@@ -69,6 +69,7 @@ class NistCveSearcher():
         nvd_search_url = 'https://services.nvd.nist.gov/rest/json/cves/2.0?keywordSearch='
 
         try:
+            search_result = None
             if nist_api_key:
                 search_result = requests.get(url = nvd_search_url + mod_name, headers={'apiKey': nist_api_key})
             else:


### PR DESCRIPTION
It used to be the case that the NIST API worked just fine if you sent a request with the `apiKey` header without a key set. Now days, if you add that header to a request with anything other than a valid NIST key the request fails.

This PR ensures the `apiKey` header is added only if a NIST TOKEN is set. This means if the configuration is not changed to add a token, there is no `apiKey` header included and calls will succeed but within the rate limits set by NIST.