### PR TITLE
Extend Bazel parser to find arbitrary number of dependencies

### DIFF
--- a/src/dependency_searchers/package_parsers.py
+++ b/src/dependency_searchers/package_parsers.py
@@ -99,12 +99,18 @@ class BazelParser(PackageParser):
             if name:
                 version_pattern = re.compile(
                     r'\s*http.*' + name + r'-([a-zA-Z0-9-\.]*)\.tar|' + \
-                    r'\s*http.*' + name + r'-([a-zA-Z0-9-\.]*)\.')
+                    r'\s*http.*' + name + r'-([a-zA-Z0-9-\.]*)\.|' + \
+                    r'\s*strip_prefix\s*=\s*(?:\"|\')' + name + r'-(.*)(?:\"|\')')
 
                 match = version_pattern.search(line)
 
                 if match:
-                    version_match = match.group(1) if match.group(1) else match.group(2)
+                    if match.group(1):
+                        version_match = match.group(1)
+                    elif match.group(2):
+                        version_match = match.group(2)
+                    else:
+                        version_match = match.group(3)
 
                     # some version numbers have a 'v' before the version number and some version numbers
                     # have a '-latest' at the end, we need to remove this to accurately match the version

--- a/src/dependency_searchers/package_parsers.py
+++ b/src/dependency_searchers/package_parsers.py
@@ -81,14 +81,14 @@ class BazelParser(PackageParser):
         you can map known dependencies to their licenses in licenses.csv in this
         directory if you want this data available in reports. """
 
-
-
     def parse(self, package_contents: str) -> List[Dict[str, str]]:
         dependencies = []
 
         name_pattern = re.compile(r'\s*name\s*=\s*(?:\"|\')(.*)(?:\"|\')')
         name = ''
         version = ''
+
+        package_contents = str(package_contents, "UTF-8")
 
         for line in package_contents.split('\n'):
             match = name_pattern.match(line)
@@ -123,7 +123,8 @@ class BazelParser(PackageParser):
                 dependency = {'MODULE_SOURCE': str('Bazel Dependencies'), 'ModuleName': name,
                               'Version': version, 'License': dependency_license}
                 dependencies.append(dependency)
-                break
+                name = ''
+                version = ''
 
         return dependencies
 

--- a/tests/test_bazel_parser.py
+++ b/tests/test_bazel_parser.py
@@ -36,7 +36,7 @@ def load_asio_repo():
         name = \"asio\",
         build_file = \"@//third_party/asio:asio.BUILD\",
         sha256 = \"fa8c3a16dc2163f5b3451f2a14ce95277c971f46700497d4e94af6059c00dc06\",
-        strip_prefix = \"asio-asio-1-12-0\",
+        strip_prefix = \"asio-1-12-0\",
         urls = [
             \"https://registry.ci.motional.com:443/artifactory/internet-resources/github.com/chriskohlhoff/asio/archive/asio-1-12-0.tar.gz\",
             \"https://github.com/chriskohlhoff/asio/archive/asio-1-12-0.tar.gz\",
@@ -79,6 +79,34 @@ def load_KTX_repo():
         self.assertEqual(dependencies[0]['Version'], '4.0.0')
         self.assertEqual(dependencies[0]['License'], 'Apache 2.0')
 
+    def test_parse_valid_bazel_file_two_dependencies(self):
+        bazel_data_two_dependencies = """
+    maybe(
+        http_archive,
+        name = "rules_python",
+        sha256 = "9acc0944c94adb23fba1c9988b48768b1bacc6583b52a2586895c5b7491e2e31",
+        strip_prefix = "rules_python-0.27.0",
+        url = "https://registry.ci.fake.com/repository/github/bazelbuild/rules_python/archive/refs/tags/0.27.0.tar.gz",
+    )
+
+    maybe(
+        http_archive,
+        name = "fmt",
+        sha256 = "5dea48d1fcddc3ec571ce2058e13910a0d4a6bab4cc09a809d8b1dd1c88ae6f2",
+        strip_prefix = "fmt-9.1.0",
+        url = "https://registry.ci.fake.com/repository/github/fmtlib/fmt/archive/9.1.0.tar.gz",
+    )
+        """
+        
+        dependencies = BazelParser().parse(bazel_data_two_dependencies)
+
+        self.assertEqual(len(dependencies), 2)
+
+        self.assertEqual(dependencies[0]['ModuleName'], 'rules_python')
+        self.assertEqual(dependencies[0]['Version'], '0.27.0')
+        
+        self.assertEqual(dependencies[1]['ModuleName'], 'fmt')
+        self.assertEqual(dependencies[1]['Version'], '9.1.0')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This should preferably be merged after pull request #13. 

The Bazel parser stops after finding the first dependency because Motional has one dependency per repository. It's not required that each dependency be in its own Bazel repository. Thus, this pull request removes the limitation and allows the parser to find all dependencies in a Bazel repository.